### PR TITLE
Enforce consistent build Ids on production releases

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,6 +93,12 @@ module.exports = {
            * Keep extension version inline with package version.
            */
           manifest.version = packageJSON.version;
+          //
+          // Keep the extension ID consistent across builds/releases
+          //
+          if (isProduction) {
+            manifest.key = 'dbhglmbgeebnchiiaechpofjkjanhfoa';
+          }
           // Add a 'random' version suffix to easily
           // see changes between builds during prod-in-test runs.
           if (!isProduction) {


### PR DESCRIPTION
Adds [All Contributors](https://allcontributors.org) spec.

## Notes
1. Forgot, I made a small tweak. This PR also includes "enforcing consistent plugin IDs across prod builds" feature.